### PR TITLE
Move buildConfig property in app module

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -95,6 +95,7 @@ android {
     buildFeatures {
         dataBinding = true
         viewBinding = true
+        buildConfig = true
     }
     lint {
         disable += listOf("NullSafeMutableLiveData")

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,5 @@
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
 android.useAndroidX=true
-android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=true
 android.nonFinalResIds=true


### PR DESCRIPTION
In most versions of Gradle, buildConfig in gradle.properties is deprecated, we need to specify property in each module of the project -> https://stackoverflow.com/questions/74634321/fixing-the-build-type-contains-custom-buildconfig-fields-but-the-feature-is-di