### PR TITLE
Switch from Mapbox SDK to MapLibre

### DIFF
--- a/.github/workflows/apikeys-ci.xml
+++ b/.github/workflows/apikeys-ci.xml
@@ -1,6 +1,8 @@
 <resources>
    <string name="google_maps_key" templateMergeStrategy="preserve" translatable="false">ci</string>
    <string name="mapbox_key" translatable="false">ci</string>
+   <string name="jawg_key" translatable="false">ci</string>
+   <string name="arcgis_key" translatable="false">ci</string>
    <string name="goingelectric_key" translatable="false">ci</string>
    <string name="chargeprice_key" translatable="false">ci</string>
    <string name="openchargemap_key" translatable="false">ci</string>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
           OPENCHARGEMAP_API_KEY: ${{ secrets.OPENCHARGEMAP_API_KEY }}
           CHARGEPRICE_API_KEY: ${{ secrets.CHARGEPRICE_API_KEY }}
           MAPBOX_API_KEY: ${{ secrets.MAPBOX_API_KEY }}
+          JAWG_API_KEY: ${{ secrets.JAWG_API_KEY }}
+          ARCGIS_API_KEY: ${{ secrets.ARCGIS_API_KEY }}
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
           FRONYX_API_KEY: ${{ secrets.FRONYX_API_KEY }}
           ACRA_CRASHREPORT_CREDENTIALS: ${{ secrets.ACRA_CRASHREPORT_CREDENTIALS }}

--- a/README.md
+++ b/README.md
@@ -77,5 +77,12 @@ You can use our [Weblate page](https://hosted.weblate.org/projects/evmap/) to he
 into new languages.
 
 <a href="https://hosted.weblate.org/engage/evmap/">
-<img src="https://hosted.weblate.org/widgets/evmap/-/open-graph.png" width="500" alt="Translation status" />
+<img src="https://hosted.weblate.org/widgets/evmap/-/open-graph.png" width="400" alt="Translation status" />
 </a>
+
+Sponsors
+--------
+
+<a href="https://www.jawg.io"><img src="https://www.jawg.io/static/Blue@10x-9cdc4596e4e59acbd9ead55e9c28613e.png" alt="JawgMaps" height="58"/></a><br>
+Since mid 2024, **JawgMaps** provides their OpenStreetMap vector map tiles service to EVMap for
+free, i.e. the background map displayed in the app if OpenStreetMap is selected as the data source.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Features
 - Android Auto & Android Automotive OS integration
 - No ads, fully open source
 - Compatible with Android 5.0 and above
-- Can use Google Maps or Mapbox (OpenStreetMap) as map backends - the version available on F-Droid only uses Mapbox.
+- Can use Google Maps or OpenStreetMap as map backends - the version available on F-Droid only uses
+  OSM.
 
 Screenshots
 -----------
@@ -43,7 +44,8 @@ EVMap uses and put them into the app in the form of a resource file called `apik
 features and how they can be obtained in our [documentation page](doc/api_keys.md).
 
 There are three different build flavors, `googleNormal`, `fossNormal` and `googleAutomotive`.
-- The `foss` variants only use Mapbox data and should run on most Android devices, even without
+
+- The `foss` variants only use OSM data and should run on most Android devices, even without
   Google Play Services.
     - `fossNormal` is intended to run on smartphones and tablets, and also includes the Android
       Auto app for use on the car display (however for that to work, the Android Auto app is

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -146,6 +146,28 @@ android {
         if (mapboxKey != null) {
             resValue("string", "mapbox_key", mapboxKey)
         }
+        var jawgKey =
+            System.getenv("JAWG_API_KEY") ?: project.findProperty("JAWG_API_KEY")?.toString()
+        if (jawgKey == null && project.hasProperty("JAWG_API_KEY_ENCRYPTED")) {
+            jawgKey = decode(
+                project.findProperty("JAWG_API_KEY_ENCRYPTED").toString(),
+                "FmK.d,-f*p+rD+WK!eds"
+            )
+        }
+        if (jawgKey != null) {
+            resValue("string", "jawg_key", jawgKey)
+        }
+        var arcgisKey =
+            System.getenv("ARCGIS_API_KEY") ?: project.findProperty("ARCGIS_API_KEY")?.toString()
+        if (arcgisKey == null && project.hasProperty("ARCGIS_API_KEY_ENCRYPTED")) {
+            arcgisKey = decode(
+                project.findProperty("ARCGIS_API_KEY_ENCRYPTED").toString(),
+                "FmK.d,-f*p+rD+WK!eds"
+            )
+        }
+        if (arcgisKey != null) {
+            resValue("string", "arcgis_key", jawgKey)
+        }
         var chargepriceKey =
             System.getenv("CHARGEPRICE_API_KEY") ?: project.findProperty("CHARGEPRICE_API_KEY")
                 ?.toString()
@@ -261,28 +283,11 @@ dependencies {
     automotiveImplementation("androidx.car.app:app-automotive:$carAppVersion")
 
     // AnyMaps
-    val anyMapsVersion = "4854581f72"
+    val anyMapsVersion = "c087b3e7c2"
     implementation("com.github.ev-map.AnyMaps:anymaps-base:$anyMapsVersion")
     googleImplementation("com.github.ev-map.AnyMaps:anymaps-google:$anyMapsVersion")
     googleImplementation("com.google.android.gms:play-services-maps:18.2.0")
-    implementation("com.github.ev-map.AnyMaps:anymaps-mapbox:$anyMapsVersion") {
-        exclude(group = "com.mapbox.mapboxsdk", module = "mapbox-android-accounts")
-        exclude(group = "com.mapbox.mapboxsdk", module = "mapbox-android-telemetry")
-        exclude(group = "com.google.android.gms", module = "play-services-location")
-        exclude(group = "com.mapbox.mapboxsdk", module = "mapbox-android-core")
-    }
-    // original version of mapbox-android-core
-    googleImplementation("com.mapbox.mapboxsdk:mapbox-android-core:2.0.1")
-    // patched version that removes build-time dependency on GMS (-> no Google location services)
-    fossImplementation("com.github.ev-map:mapbox-events-android:a21c324501")
-
-    implementation("com.mapbox.mapboxsdk:mapbox-android-sdk") {
-        exclude(group = "com.mapbox.mapboxsdk", module = "mapbox-android-accounts")
-        exclude(group = "com.mapbox.mapboxsdk", module = "mapbox-android-telemetry")
-        version {
-            strictly("9.1.0-SNAPSHOT")
-        }
-    }
+    implementation("com.github.ev-map.AnyMaps:anymaps-maplibre:$anyMapsVersion")
 
     // Google Places
     googleImplementation("com.google.android.libraries.places:places:3.3.0")

--- a/app/src/foss/res/values-cs/strings.xml
+++ b/app/src/foss/res/values-cs/strings.xml
@@ -2,5 +2,5 @@
 <resources>
     <string name="donations_info" formatted="false">Pomohla vám EVMap? Podpořte její vývoj zasláním finančního daru vývojáři.</string>
     <string name="donate_paypal">Přispět pomocí PayPalu</string>
-    <string name="data_sources_hint">Mapová data v aplikaci poskytuje služba OpenStreetMap (Mapbox).</string>
+    <string name="data_sources_hint">Mapová data v aplikaci poskytuje služba OpenStreetMap.</string>
 </resources>

--- a/app/src/foss/res/values-de/strings.xml
+++ b/app/src/foss/res/values-de/strings.xml
@@ -2,5 +2,5 @@
 <resources>
     <string name="donations_info" formatted="false">Findest du EVMap nützlich? Unterstütze die Weiterentwicklung der App mit einer Spende an den Entwickler.</string>
     <string name="donate_paypal">Mit PayPal spenden</string>
-    <string name="data_sources_hint">Die Kartendaten für die App stammen von OpenStreetMap (Mapbox).</string>
+    <string name="data_sources_hint">Die Kartendaten für die App stammen von OpenStreetMap.</string>
 </resources>

--- a/app/src/foss/res/values-fr/strings.xml
+++ b/app/src/foss/res/values-fr/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="donations_info" formatted="false">Trouvez-vous EVMap utile \? Soutenez son développement en envoyant un don au développeur.</string>
-    <string name="data_sources_hint">Les données cartographiques de l\'application sont fournies par OpenStreetMap (Mapbox).</string>
+    <string name="data_sources_hint">Les données cartographiques de l\'application sont fournies par OpenStreetMap.</string>
     <string name="donate_paypal">Faire un don avec PayPal</string>
 </resources>

--- a/app/src/foss/res/values-nb-rNO/strings.xml
+++ b/app/src/foss/res/values-nb-rNO/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="donate_paypal">Doner med PayPal</string>
-    <string name="data_sources_hint">Kartdata i programmet tilbys av OpenStreetMap (Mapbox).</string>
+    <string name="data_sources_hint">Kartdata i programmet tilbys av OpenStreetMap.</string>
     <string name="donations_info" formatted="false">Synes du EVMap er nyttig\? Støtt utviklingen ved å sende en slant til utvikleren.</string>
 </resources>

--- a/app/src/foss/res/values-nl/strings.xml
+++ b/app/src/foss/res/values-nl/strings.xml
@@ -2,5 +2,5 @@
 <resources>
     <string name="donations_info" formatted="false">Vond je EVMap nuttig\? Je kan de ontwikkeling ondersteunen door een donatie te sturen naar de ontwikkelaar.</string>
     <string name="donate_paypal">Doneer via PayPal</string>
-    <string name="data_sources_hint">De kaartgegevens zijn afkomstig van OpenStreetMap (Mapbox).</string>
+    <string name="data_sources_hint">De kaartgegevens zijn afkomstig van OpenStreetMap.</string>
 </resources>

--- a/app/src/foss/res/values-pt/strings.xml
+++ b/app/src/foss/res/values-pt/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="data_sources_hint">Os dados do mapa são fornecidos pelo OpenStreetMap (Mapbox).</string>
+    <string name="data_sources_hint">Os dados do mapa são fornecidos pelo OpenStreetMap.</string>
     <string name="donate_paypal">Doar com o PayPal</string>
     <string name="donations_info" formatted="false">Acha que o EVMap é útil\? Apoie a manutenção e desenvolvimento com uma doação para o desenvolvedor da app.</string>
 </resources>

--- a/app/src/foss/res/values-ro/strings.xml
+++ b/app/src/foss/res/values-ro/strings.xml
@@ -2,5 +2,5 @@
 <resources>
     <string name="donations_info" formatted="false">Crezi ca EVMap este util? Sprijina dezvoltarea printr-o donatie pentru dezvoltator.</string>
     <string name="donate_paypal">Doneaza cu PayPal</string>
-    <string name="data_sources_hint">Hartile din aplicatie sunt furnizate de OpenStreetMap (Mapbox).</string>
+    <string name="data_sources_hint">Hartile din aplicatie sunt furnizate de OpenStreetMap.</string>
 </resources>

--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -2,5 +2,5 @@
 <resources>
     <string name="donations_info" formatted="false">Do you find EVMap useful? Support its development by sending a donation to the developer.</string>
     <string name="donate_paypal">Donate with PayPal</string>
-    <string name="data_sources_hint">Map data in the app is provided by OpenStreetMap (Mapbox).</string>
+    <string name="data_sources_hint">Map data in the app is provided by OpenStreetMap.</string>
 </resources>

--- a/app/src/google/res/values-cs/strings.xml
+++ b/app/src/google/res/values-cs/strings.xml
@@ -3,5 +3,5 @@
     <string name="donations_info" formatted="false">Pomohla vám EVMap? Podpořte její vývoj posláním finančního daru vývojáři.
 \n
 \nGoogle si z každého daru strhne 15 %.</string>
-    <string name="data_sources_hint">V nastavení můžete také pro mapová data přepínat mezi službami Mapy Google a OpenStreetMap (Mapbox).</string>
+    <string name="data_sources_hint">V nastavení můžete také pro mapová data přepínat mezi službami Mapy Google a OpenStreetMap.</string>
 </resources>

--- a/app/src/google/res/values-de/strings.xml
+++ b/app/src/google/res/values-de/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="donations_info" formatted="false">Findest du EVMap nützlich? Unterstütze die Weiterentwicklung der App mit einer Spende an den Entwickler.\n\nGoogle zieht von der Spende 15% Gebühren ab.</string>
-    <string name="data_sources_hint">In den Einstellungen kannst du auch zwischen Google Maps und OpenStreetMap (Mapbox) für die Kartendaten wechseln.</string>
+    <string name="data_sources_hint">In den Einstellungen kannst du auch zwischen Google Maps und OpenStreetMap für die Kartendaten wechseln.</string>
 </resources>

--- a/app/src/google/res/values-fr/strings.xml
+++ b/app/src/google/res/values-fr/strings.xml
@@ -3,5 +3,5 @@
     <string name="donations_info" formatted="false">Trouvez-vous EVMap utile \? Soutenez son développement en envoyant un don au développeur.
 \n
 \nGoogle prend 15% sur chaque don.</string>
-    <string name="data_sources_hint">Dans les paramètres, vous pouvez également choisir entre Google Maps et OpenStreetMap (Mapbox) pour les données cartographiques.</string>
+    <string name="data_sources_hint">Dans les paramètres, vous pouvez également choisir entre Google Maps et OpenStreetMap pour les données cartographiques.</string>
 </resources>

--- a/app/src/google/res/values-nb-rNO/strings.xml
+++ b/app/src/google/res/values-nb-rNO/strings.xml
@@ -3,5 +3,5 @@
     <string name="donations_info" formatted="false">Synes du EVMap er nyttig\? Støtt utviklingen ved å sende penger til utvikleren.
 \n
 \nGoogle tar 15% av alle donasjoner.</string>
-    <string name="data_sources_hint">I innstillingene kan du også bytte mellom Google Maps og OpenStreetMap (Mapbox) for kartdata.</string>
+    <string name="data_sources_hint">I innstillingene kan du også bytte mellom Google Maps og OpenStreetMap for kartdata.</string>
 </resources>

--- a/app/src/google/res/values-nl/strings.xml
+++ b/app/src/google/res/values-nl/strings.xml
@@ -3,5 +3,5 @@
     <string name="donations_info" formatted="false">Vind je EVMap nuttig\? Je kan de ontwikkeling steunen via een donatie aan de ontwikkelaar.
 \n
 \nGoogle houdt 15% in van elke donatie.</string>
-    <string name="data_sources_hint">In de instellingen kan je ook wisselen tussen Google Maps en OpenStreetMap (Mapbox) voor de kaartgegevens.</string>
+    <string name="data_sources_hint">In de instellingen kan je ook wisselen tussen Google Maps en OpenStreetMap voor de kaartgegevens.</string>
 </resources>

--- a/app/src/google/res/values-pt/strings.xml
+++ b/app/src/google/res/values-pt/strings.xml
@@ -3,5 +3,5 @@
     <string name="donations_info" formatted="false">Acha que o EVMap é útil\? Apoie a manutenção e desenvolvimento com uma doação para o desenvolvedor da app.
 \n
 \nA Google cobra 15% de cada doação.</string>
-    <string name="data_sources_hint">Também pode mudar entre o Google Maps e OpenStreetMap (Mapbox) nas definições da app.</string>
+    <string name="data_sources_hint">Também pode mudar entre o Google Maps e OpenStreetMap nas definições da app.</string>
 </resources>

--- a/app/src/google/res/values/arrays.xml
+++ b/app/src/google/res/values/arrays.xml
@@ -2,7 +2,7 @@
 <resources>
     <string-array name="pref_map_provider_names">
         <item>@string/pref_provider_google_maps</item>
-        <item>@string/pref_provider_osm_mapbox</item>
+        <item>@string/pref_provider_osm</item>
     </string-array>
     <string-array name="pref_map_provider_values" translatable="false">
         <item>google</item>

--- a/app/src/google/res/values/strings.xml
+++ b/app/src/google/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="donations_info" formatted="false">Do you find EVMap useful? Support its development by sending a donation to the developer.\n\nGoogle takes 15% off every donation.</string>
-    <string name="data_sources_hint">In the settings you can also switch between Google Maps and OpenStreetMap (Mapbox) for the map data.</string>
+    <string name="data_sources_hint">In the settings you can also switch between Google Maps and OpenStreetMap for the map data.</string>
 </resources>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,6 +48,14 @@
             android:name="com.mapbox.ACCESS_TOKEN"
             android:value="@string/mapbox_key" />
 
+        <meta-data
+            android:name="io.jawg.ACCESS_TOKEN"
+            android:value="@string/jawg_key" />
+
+        <meta-data
+            android:name="com.arcgis.ACCESS_TOKEN"
+            android:value="@string/arcgis_key" />
+
         <activity
             android:name=".MapsActivity"
             android:label="@string/app_name"

--- a/app/src/main/java/net/vonforst/evmap/autocomplete/MapboxAutocompleteProvider.kt
+++ b/app/src/main/java/net/vonforst/evmap/autocomplete/MapboxAutocompleteProvider.kt
@@ -113,8 +113,7 @@ class MapboxAutocompleteProvider(val context: Context) : AutocompleteProvider {
 
     override fun getAttributionString(): Int = R.string.powered_by_mapbox
 
-    override fun getAttributionImage(dark: Boolean): Int =
-        if (dark) com.mapbox.mapboxsdk.R.drawable.mapbox_logo_icon else R.drawable.mapbox_logo
+    override fun getAttributionImage(dark: Boolean): Int = R.drawable.mapbox_logo
 }
 
 private fun BoundingBox.toLatLngBounds(): LatLngBounds {

--- a/app/src/main/java/net/vonforst/evmap/fragment/MapFragment.kt
+++ b/app/src/main/java/net/vonforst/evmap/fragment/MapFragment.kt
@@ -225,12 +225,12 @@ class MapFragment : Fragment(), OnMapReadyCallback, MapsActivity.FragmentCallbac
             mapFragment = MapFragment()
             mapFragment!!.priority = arrayOf(
                 when (provider) {
-                    "mapbox" -> MapFragment.MAPBOX
+                    "mapbox" -> MapFragment.MAPLIBRE
                     "google" -> MapFragment.GOOGLE
                     else -> null
                 },
                 MapFragment.GOOGLE,
-                MapFragment.MAPBOX
+                MapFragment.MAPLIBRE
             )
             childFragmentManager
                 .beginTransaction()
@@ -275,7 +275,7 @@ class MapFragment : Fragment(), OnMapReadyCallback, MapsActivity.FragmentCallbac
 
             // set map padding so that compass is not obstructed by toolbar
             mapTopPadding = systemWindowInsetTop + (48 * density).toInt() + (16 * density).toInt()
-            // if we actually use map.setPadding here, Mapbox will re-trigger onApplyWindowInsets
+            // if we actually use map.setPadding here, MapLibre will re-trigger onApplyWindowInsets
             // and cause an infinite loop. So we rely on onMapReady being called later than
             // onApplyWindowInsets.
 
@@ -1052,6 +1052,9 @@ class MapFragment : Fragment(), OnMapReadyCallback, MapsActivity.FragmentCallbac
         val context = this.context ?: return
         chargerIconGenerator = ChargerIconGenerator(context, map.bitmapDescriptorFactory)
 
+        vm.mapTrafficSupported.value =
+            mapFragment?.let { AnyMap.Feature.TRAFFIC_LAYER in it.supportedFeatures } ?: false
+
         if (BuildConfig.FLAVOR.contains("google") && mapFragment!!.priority[0] == MapFragment.GOOGLE) {
             // Google Maps: icons can be generated in background thread
             lifecycleScope.launch {
@@ -1060,7 +1063,7 @@ class MapFragment : Fragment(), OnMapReadyCallback, MapsActivity.FragmentCallbac
                 }
             }
         } else {
-            // Mapbox: needs to be run on main thread
+            // MapLibre: needs to be run on main thread
             chargerIconGenerator.preloadCache()
         }
 

--- a/app/src/main/java/net/vonforst/evmap/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/net/vonforst/evmap/viewmodel/MapViewModel.kt
@@ -3,7 +3,16 @@ package net.vonforst.evmap.viewmodel
 import android.app.Application
 import android.graphics.Point
 import android.os.Parcelable
-import androidx.lifecycle.*
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.distinctUntilChanged
+import androidx.lifecycle.liveData
+import androidx.lifecycle.map
+import androidx.lifecycle.switchMap
+import androidx.lifecycle.viewModelScope
 import com.car2go.maps.AnyMap
 import com.car2go.maps.Projection
 import com.car2go.maps.model.LatLng
@@ -24,7 +33,17 @@ import net.vonforst.evmap.api.openchargemap.OCMConnection
 import net.vonforst.evmap.api.openchargemap.OCMReferenceData
 import net.vonforst.evmap.api.stringProvider
 import net.vonforst.evmap.autocomplete.PlaceWithBounds
-import net.vonforst.evmap.model.*
+import net.vonforst.evmap.model.ChargeLocation
+import net.vonforst.evmap.model.Chargepoint
+import net.vonforst.evmap.model.ChargepointListItem
+import net.vonforst.evmap.model.FILTERS_DISABLED
+import net.vonforst.evmap.model.FILTERS_FAVORITES
+import net.vonforst.evmap.model.Favorite
+import net.vonforst.evmap.model.FavoriteWithDetail
+import net.vonforst.evmap.model.FilterValue
+import net.vonforst.evmap.model.FilterValues
+import net.vonforst.evmap.model.getMultipleChoiceValue
+import net.vonforst.evmap.model.getSliderValue
 import net.vonforst.evmap.storage.AppDatabase
 import net.vonforst.evmap.storage.ChargeLocationsRepository
 import net.vonforst.evmap.storage.EncryptedPreferenceDataStore
@@ -279,6 +298,12 @@ class MapViewModel(application: Application, private val state: SavedStateHandle
             observeForever {
                 prefs.mapType = it
             }
+        }
+    }
+
+    val mapTrafficSupported: MutableLiveData<Boolean> by lazy {
+        MutableLiveData<Boolean>().apply {
+            value = false
         }
     }
 

--- a/app/src/main/res/layout/map_layers.xml
+++ b/app/src/main/res/layout/map_layers.xml
@@ -80,6 +80,7 @@
             android:layout_marginEnd="16dp"
             android:text="@string/map_details"
             android:textAppearance="@style/TextAppearance.Material3.TitleSmall"
+            app:goneUnless="@{vm.mapTrafficSupported}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintStart_toStartOf="parent"
@@ -94,6 +95,7 @@
             android:layout_marginEnd="16dp"
             android:text="@string/map_traffic"
             android:checked="@={vm.mapTrafficEnabled}"
+            app:goneUnless="@{vm.mapTrafficSupported}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/textView23" />

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -271,6 +271,7 @@
     <string name="pref_chargeprice_currency_sek">Schwedische Krone (SEK)</string>
     <string name="pref_chargeprice_currency_usd">US-Dollar (USD)</string>
     <string name="pref_provider_google_maps">Google Maps</string>
+    <string name="pref_provider_osm">OpenStreetMap</string>
     <string name="pref_provider_osm_mapbox">OpenStreetMap (Mapbox)</string>
     <string name="about_contributors">Mitwirkende</string>
     <string name="about_contributors_text">Dank an alle Mitwirkenden für ihre Beiträge von Code und Übersetzungen für EVMap:</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -271,6 +271,7 @@
     <string name="pref_chargeprice_currency_sek">Swedish krona (SEK)</string>
     <string name="pref_chargeprice_currency_usd">US dollar (USD)</string>
     <string name="pref_provider_google_maps">Google Maps</string>
+    <string name="pref_provider_osm">OpenStreetMap</string>
     <string name="pref_provider_osm_mapbox">OpenStreetMap (Mapbox)</string>
     <string name="about_contributors">Contributors</string>
     <string name="about_contributors_text">Thanks to all contributors for their coding and translation contributions to EVMap:</string>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,9 +26,6 @@ allprojects {
         mavenCentral()
         //noinspection JcenterRepositoryObsolete
         maven { setUrl("https://jitpack.io") }
-        maven {
-            setUrl("https://raw.githubusercontent.com/ev-map/mapbox-gl-native-android/mvn")
-        }
     }
 }
 

--- a/doc/api_keys.md
+++ b/doc/api_keys.md
@@ -17,6 +17,12 @@ be put into the app in the form of a resource file called `apikeys.xml` under
    <string name="mapbox_key" translatable="false">
       insert your Mapbox key here
    </string>
+   <string name="jawg_key" translatable="false">
+      insert your Jawg Maps key here
+   </string>
+   <string name="arcgis_key" translatable="false">
+      insert your ArcGIS Maps key here
+   </string>
    <string name="goingelectric_key" translatable="false">
       insert your GoingElectric key here
    </string>
@@ -52,10 +58,12 @@ Map providers
 
 The different Map SDKs are wrapped by our [fork](https://github.com/ev-map/AnyMaps) of the
 [AnyMaps](https://github.com/sharenowTech/AnyMaps) library to provide a common API. The `google`
-build flavor of the app includes both Google Maps and Mapbox and allows the user to switch between
-the two, while the `foss` flavor only includes the Mapbox SDK.
+build flavor of the app includes both Google Maps and OpenStreetMap (vector tiles from
+[Jawg Maps](https://www.jawg.io/en/) through [MapLibre](https://maplibre.org/)) and allows the user
+to switch between the two, while the `foss` flavor only includes OSM.
 
-> ⚠️ When testing the app using the Android Emulator, we recommend using Google Maps and not Mapbox, as the latter has
+> ⚠️ When testing the app using the Android Emulator, we recommend using Google Maps and not
+> OSM/MapLibre, as the latter has
 [issues displaying the markers](https://github.com/mapbox/mapbox-gl-native/issues/10829). It works fine on real Android devices.
 
 ### Google Maps
@@ -77,9 +85,39 @@ the two, while the `foss` flavor only includes the Mapbox SDK.
 
 </details>
 
+### Jawg Maps
+
+[Dynamic Maps](https://www.jawg.io/docs/apidocs/maps/)
+
+<details>
+<summary>How to obtain an API key</summary>
+
+1. [Sign up](https://www.jawg.io/lab) for a Jawg account
+2. Under [Access Tokens](https://www.jawg.io/lab/access-tokens), copy your default access token or
+   create a new one. Do not restrict it to a specific origin (this setting is not compatible with
+   Android apps).
+
+</details>
+
+### ArcGIS
+
+[World Imagery basemap](https://www.arcgis.com/home/item.html?id=10df2279f9684e4a9f6a7f08febac2a9)
+*We use this for the satellite map, as [Jawg's](https://blog.jawg.io/satellite-imaging/) satellite
+style does not have global coverage.*
+
+<details>
+<summary>How to obtain an API key</summary>
+
+1. [Sign up](https://developers.arcgis.com/dashboard/) for an ArcGIS developer account
+2. In the dashboard, copy your default API key or create a new one. It has to have access to the
+   "Basemaps" service.
+
+</details>
+
 ### Mapbox
 
-[Maps SDK for Android](https://docs.mapbox.com/android/maps)
+[Geocoding API](https://docs.mapbox.com/api/search/geocoding/)
+*previously we also used Mapbox's Maps SDK, but this has now been switched to Jawg Maps.*
 
 <details>
 <summary>How to obtain an API key</summary>
@@ -90,7 +128,6 @@ the two, while the `foss` flavor only includes the Mapbox SDK.
    to a specific URL (this setting is not compatible with Android apps)
 
 </details>
-
 
 Charging station databases
 --------------------------

--- a/fastlane/metadata/android/cs-CZ/full_description.txt
+++ b/fastlane/metadata/android/cs-CZ/full_description.txt
@@ -5,7 +5,7 @@ Funkce:
 - Zobrazuje všechny nabíjecí stanice z komunitou spravovaných databází GoingElectric.de a Open Charge Map.
 - Informace o dostupnosti v reálném čase (pouze v Evropě)
 - Integrované srovnání cen pomocí Chargeprice.app (pouze v Evropě)
-- Mapové podklady z OpenStreetMap (Mapbox)
+- Mapové podklady z OpenStreetMap
 - Vyhledávání míst
 - Pokročilé možnosti filtrování, včetně uložených profilů filtrů
 - Seznam oblíbených, také s informacemi o dostupnosti

--- a/fastlane/metadata/android/de-DE/full_description.txt
+++ b/fastlane/metadata/android/de-DE/full_description.txt
@@ -5,7 +5,7 @@ Funktionen:
 - Anzeige der Stromtankstellen aus den Stromtankstellenverzeichnissen von GoingElectric.de und Open Charge Map
 - Echtzeit-Verfügbarkeitsanzeige für viele Ladesäulen (nur in Europa)
 - Integrierter Preisvergleich für die jeweilige Ladesäule mit Chargeprice.app (nur in Europa)
-- Kartendaten von OpenStreetMap (Mapbox)
+- Kartendaten von OpenStreetMap
 - Suche nach Orten
 - Erweiterte Filterfunktionen, Filterprofile speichern
 - Favoritenliste, auch mit Anzeige der Verfügbarkeit

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -5,7 +5,7 @@ Features:
 - Shows all charging stations from the community-maintained GoingElectric.de and Open Charge Map directories
 - Realtime availability information (only in Europe)
 - Integrated price comparison using Chargeprice.app (only in Europe)
-- Map data from OpenStreetMap (Mapbox)
+- Map data from OpenStreetMap
 - Search for places
 - Advanced filtering options, including saved filter profiles
 - Favorites list, also with availability information

--- a/fastlane/metadata/android/fr/full_description.txt
+++ b/fastlane/metadata/android/fr/full_description.txt
@@ -5,7 +5,7 @@ Caractéristiques :
 - Affiche toutes les stations de recharge des répertoires GoingElectric.de et Open Charge Map gérés par la communauté.
 - Informations sur la disponibilité en temps réel (uniquement en Europe)
 - Comparaison des prix intégrée grâce à Chargeprice.app (uniquement en Europe)
-- Données cartographiques provenant d'OpenStreetMap (Mapbox)
+- Données cartographiques provenant d'OpenStreetMap
 - Recherche de lieux
 - Options de filtrage avancées, y compris les profils de filtrage enregistrés
 - Liste de favoris, avec également des informations sur la disponibilité

--- a/fastlane/metadata/android/nb-NO/full_description.txt
+++ b/fastlane/metadata/android/nb-NO/full_description.txt
@@ -5,7 +5,7 @@ Du finner info om ladestasjoner i hele verden og sanntidsinfo for mange av dem s
 - Materiell design
 - Sanntidsinfo (kun i Europa)
 - Integrert sammenligningsinfo ved bruk av Chargeprice.app (kun i Europa)
-- Kartdata fra OpenStreetMap (Mapbox)
+- Kartdata fra OpenStreetMap
 - Søk etter steder
 - Avanserte filtreringsvalg, inkludert lagrede filterprofiler
 - Favorittliste, som også har tilgjengelighetsinfo

--- a/fastlane/metadata/android/nl-NL/full_description.txt
+++ b/fastlane/metadata/android/nl-NL/full_description.txt
@@ -5,7 +5,7 @@ Kenmerken:
 - Toont alle laadpunten van de GoingElectric.de en Open Charge Map databanken
 - Real-time status (enkel in Europa)
 - Geïntegreerde prijsvergelijking via Chargeprice.app (enkel in Europe)
-- Kaartgegevens van OpenStreetMap (Mapbox)
+- Kaartgegevens van OpenStreetMap
 - Zoek naar locaties
 - Geavanceerde filtermogelijkheden, inclusief bewaarde filterprofielen
 - Lijst van favorieten, met statusinformatie

--- a/fastlane/metadata/android/pt/full_description.txt
+++ b/fastlane/metadata/android/pt/full_description.txt
@@ -5,7 +5,7 @@ Destaques:
 - Mostra todas as estações de carregamento dos diretórios GoingElectric.de e Open Charge Map mantidos pela comunidade
 - Informação de disponibilidade em tempo real (apenas na Europa)
 - Comparação de preços integrada usando o Chargeprice.app (apenas na Europa)
-- Informação do mapa via OpenStreetMap (Mapbox)
+- Informação do mapa via OpenStreetMap
 - Pesquise lugares
 - Opções de filtragem avançadas, incluindo filtros de pesquisa que podem ser guardados
 - Lista de favoritos, também com informações de disponibilidade


### PR DESCRIPTION
This PR switches EVMap from the old [Mapbox SDK](https://github.com/mapbox/mapbox-gl-native-android/) version we have been using (the last version that was under a libre license) to [MapLibre](https://github.com/maplibre/maplibre-native), a fork with an open license that is actively maintained.

A big thanks to [Jawg Maps](https://www.jawg.io/), who offered to sponsor map tile hosting for EVMap - their map tiles will now be used as the source for EVMap's OpenStreetMap background maps (i.e. by default in the F-Droid version of the app, and when the user chooses OSM maps in the settings in the Google Play version).

This will make it easier to continue distributing the app through F-Droid (see #197, cc @linsui), resolves privacy concerns regarding Mapbox's use of an SKU token to implement per-user billing (#141), and of course makes us benefit from new features and improvements that are being implemented in the MapLibre library.

A couple caveats to note:
- Geocoding (i.e. the place search bar) will still be using Mapbox APIs, thus a Mapbox API key will still be required for that feature. Jawg do also offer geocoding APIs, but that is not included in their sponsoring as of now.
- It seems that Jawg currently do not offer a traffic data layer for maps, so this feature will be unavailable for now when OpenStreetMap maps are selected.
- Jawg do offer satellite images, but [only in a few countries](https://blog.jawg.io/satellite-imaging/) as of now. I don't think satellite maps are a very commonly used feature in EVMap, so for now I switched this map style to use tiles from [ArcGIS](https://www.arcgis.com/home/item.html?id=10df2279f9684e4a9f6a7f08febac2a9) and hope their free tier will be sufficient.