### PR TITLE
Add support for Android 13+ themed icons

### DIFF
--- a/_img/appicon_monochrome.svg
+++ b/_img/appicon_monochrome.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Ebene_1" data-name="Ebene 1" xmlns="http://www.w3.org/2000/svg" version="1.1"
+    viewBox="0 0 108 108">
+    <defs>
+        <style>
+            .cls-1 {
+            fill: #000;
+            stroke-width: 0px;
+            }
+        </style>
+    </defs>
+    <path class="cls-1"
+        d="M53.9,28c-8.8,0-15.9,7.1-15.9,15.9s13.4,18.2,15,35.3c0,.5.5.9,1,.9s.9-.4,1-.9c1.6-17.1,15-23.3,15-35.3-.1-8.8-7.2-15.9-16-15.9ZM59,43.1l-6.1,10.5v-7.9h-2.6v-9.6s8.8,0,8.7,0l-3.5,7h3.5Z" />
+</svg>

--- a/app/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/app/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -1,0 +1,19 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="228.3471"
+    android:viewportHeight="228.3471">
+    <group
+        android:translateX="12.1735537"
+        android:translateY="18.1735537">
+
+        <path
+            android:pathData="M101.9,44.1c-17.5,0 -31.7,14.2 -31.7,31.7c0,23.9 26.7,36.4 29.9,70.5c0.1,1 0.9,1.7 1.9,1.7s1.8,-0.7 1.9,-1.7c3.2,-34.1 29.9,-46.6 29.9,-70.5C133.6,58.2 119.4,44.1 101.9,44.1z"
+            android:strokeColor="#000000"
+            android:strokeWidth="8"/>
+
+        <path
+            android:fillColor="#000000"
+            android:pathData="M94.6,60.3v19.2h5.2v15.7l12.2,-21h-7l7,-14C112.1,60.3 94.6,60.3 94.6,60.3z" />
+    </group>
+</vector>

--- a/app/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/app/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -1,19 +1,10 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="108dp"
     android:height="108dp"
-    android:viewportWidth="228.3471"
-    android:viewportHeight="228.3471">
-    <group
-        android:translateX="12.1735537"
-        android:translateY="18.1735537">
-
-        <path
-            android:pathData="M101.9,44.1c-17.5,0 -31.7,14.2 -31.7,31.7c0,23.9 26.7,36.4 29.9,70.5c0.1,1 0.9,1.7 1.9,1.7s1.8,-0.7 1.9,-1.7c3.2,-34.1 29.9,-46.6 29.9,-70.5C133.6,58.2 119.4,44.1 101.9,44.1z"
-            android:strokeColor="#000000"
-            android:strokeWidth="8"/>
-
-        <path
-            android:fillColor="#000000"
-            android:pathData="M94.6,60.3v19.2h5.2v15.7l12.2,-21h-7l7,-14C112.1,60.3 94.6,60.3 94.6,60.3z" />
-    </group>
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:pathData="M53.9,28c-8.8,0 -15.9,7.1 -15.9,15.9s13.4,18.2 15,35.3c0,0.5 0.5,0.9 1,0.9s0.9,-0.4 1,-0.9c1.6,-17.1 15,-23.3 15,-35.3 -0.1,-8.8 -7.2,-15.9 -16,-15.9ZM59,43.1l-6.1,10.5v-7.9h-2.6v-9.6s8.8,0 8.7,0l-3.5,7h3.5Z"
+        android:strokeWidth="0"
+        android:fillColor="#000" />
 </vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
 </adaptive-icon>


### PR DESCRIPTION
This adds a basic monochrome version of the app icon in order to support themed icons on newer Android versions.

Before:
![before](https://github.com/user-attachments/assets/02392e9c-dee7-4f3d-aa0c-c12898d34784)

After:
![after](https://github.com/user-attachments/assets/a3866b30-b178-4e57-9892-6d72898259d3)
