### PR TITLE
Separate connectors "type 2 socket" and "type 2 plug"

### DIFF
--- a/app/src/main/java/net/vonforst/evmap/api/Utils.kt
+++ b/app/src/main/java/net/vonforst/evmap/api/Utils.kt
@@ -8,7 +8,7 @@ import kotlin.math.abs
 private val plugNames = mapOf(
     Chargepoint.TYPE_1 to R.string.plug_type_1,
     Chargepoint.TYPE_2_UNKNOWN to R.string.plug_type_2,
-    Chargepoint.TYPE_2_PLUG to R.string.plug_type_2,
+    Chargepoint.TYPE_2_PLUG to R.string.plug_type_2_tethered,
     Chargepoint.TYPE_2_SOCKET to R.string.plug_type_2,
     Chargepoint.TYPE_3A to R.string.plug_type_3a,
     Chargepoint.TYPE_3C to R.string.plug_type_3c,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,6 +59,7 @@
     <string name="filter_connectors">Connectors</string>
     <string name="plug_type_1">Type 1</string>
     <string name="plug_type_2">Type 2</string>
+    <string name="plug_type_2_tethered">Type 2 tethered cable</string>
     <string name="plug_type_3a">Type 3A</string>
     <string name="plug_type_3c">Type 3C</string>
     <string name="plug_ccs">CCS</string>


### PR DESCRIPTION
This avoids duplicate "Type 2" entries when using filters to select connectors and when showing charger details.

(Seen when using OpenStreetMap)