### PR TITLE
Fix connector name for Type 1 connectors in EnBW availability data

### DIFF
--- a/app/src/main/java/net/vonforst/evmap/api/availability/EnBwAvailabilityDetector.kt
+++ b/app/src/main/java/net/vonforst/evmap/api/availability/EnBwAvailabilityDetector.kt
@@ -203,7 +203,7 @@ class EnBwAvailabilityDetector(client: OkHttpClient, baseUrl: String? = null) :
                 "Typ 3A" -> Chargepoint.TYPE_3A
                 "Typ 3C \"Scame\"" -> Chargepoint.TYPE_3C
                 "Typ 2" -> Chargepoint.TYPE_2_UNKNOWN
-                "Typ 1" -> Chargepoint.TYPE_1
+                "Typ 1 Steckdose" -> Chargepoint.TYPE_1
                 "Steckdose(D)" -> Chargepoint.SCHUKO
                 "CCS (Typ 1)" -> Chargepoint.CCS_TYPE_1  // US CCS, aka type1_combo
                 "CCS (Typ 2)" -> Chargepoint.CCS_TYPE_2  // EU CCS, aka type2_combo


### PR DESCRIPTION
This fixes EnBW availability status for charge locations with Type 1 connectors.

I haven't seen any chargers where the connector name is only "Typ 1" so I don't think there's any need to support this name also.