### PR TITLE
Nobil: Adapt to dropped support for Denmark, Finland and Iceland

### DIFF
--- a/app/src/main/java/net/vonforst/evmap/api/nobil/NobilApi.kt
+++ b/app/src/main/java/net/vonforst/evmap/api/nobil/NobilApi.kt
@@ -120,7 +120,7 @@ class NobilApiWrapper(
 
     override suspend fun fullDownload(): FullDownloadResult<NobilReferenceData> {
         var numTotalChargepoints = 0
-        arrayOf("DAN", "FIN", "ISL", "NOR", "SWE").forEach { countryCode ->
+        arrayOf("NOR", "SWE").forEach { countryCode ->
             val request = NobilNumChargepointsRequest(apikey, countryCode)
             val response = api.getNumChargepoints(request)
             if (!response.isSuccessful) {

--- a/app/src/main/java/net/vonforst/evmap/api/nobil/NobilModel.kt
+++ b/app/src/main/java/net/vonforst/evmap/api/nobil/NobilModel.kt
@@ -125,9 +125,6 @@ data class NobilChargerStation(
             Address(
                 chargerStationData.city,
                 when (chargerStationData.landCode) {
-                    "DAN" -> "Denmark"
-                    "FIN" -> "Finland"
-                    "ISL" -> "Iceland"
                     "NOR" -> "Norway"
                     "SWE" -> "Sweden"
                     else -> ""

--- a/doc/api_keys.md
+++ b/doc/api_keys.md
@@ -172,8 +172,8 @@ in German.
 
 ### **NOBIL**
 
-NOBIL lists charging stations in the Nordic countries (Denmark, Finland, Iceland, Norway, Sweden)
-and provides an open [API](https://info.nobil.no/api) to access the data.
+NOBIL lists charging stations in Norway and Sweden and provides an open
+[API](https://info.nobil.no/api) to access the data.
 
 To get a NOBIL API key, fill in and submit the form on [this page](https://info.nobil.no/api).
 Then, wait for an an e-mail with your API key.


### PR DESCRIPTION
Nobil has now dropped support for Denmark, Finland and Iceland and any data queries for these countries fail.

With the changes in this PR EVMap works again. However, only chargers in Norway are available right now. This is because requesting `datadump.php` without specifying a country code now returns only Norwegian chargers. Previously *all* chargers were returned. I'll ask Nobil about this as it seems like a bug on their side.